### PR TITLE
Allow for buffer address in captial letters

### DIFF
--- a/qimage2ndarray/qimageview_python.py
+++ b/qimage2ndarray/qimageview_python.py
@@ -9,7 +9,7 @@ def PyQt4_data(image):
 
 def _re_buffer_address_match(buf_repr):
     import re
-    _re_buffer_address = re.compile('<read-write buffer ptr 0x([0-9a-f]*),')
+    _re_buffer_address = re.compile('<read-write buffer ptr 0x([0-9a-fA-F]*),')
     global _re_buffer_address_match
     _re_buffer_address_match = _re_buffer_address.match
     return _re_buffer_address_match(buf_repr)


### PR DESCRIPTION
After a fresh install of anaconda on windows, `_re_buffer_address_match` failed. Probably because qimage.bits() returns the address in capital letters, like <read-write buffer ptr 0x000000000BA30040, size 1309456 at 0x000000000BB8B228>

The patch fixes this problem.