### PR TITLE
Add support for PySide in Python 3

### DIFF
--- a/qimage2ndarray/qimageview_python.py
+++ b/qimage2ndarray/qimageview_python.py
@@ -15,11 +15,15 @@ def _re_buffer_address_match(buf_repr):
     return _re_buffer_address_match(buf_repr)
 
 def PySide_data(image):
-    # PySide's QImage.bits() returns a buffer object like this:
+    # PySide's QImage.bits() returns a memoryview object that can be used
+    # directly or a buffer object like this:
     # <read-write buffer ptr 0x7fc3f4821600, size 76800 at 0x111269570>
-    ma = _re_buffer_address_match(repr(image.bits()))
-    assert ma, 'could not parse address from %r' % (image.bits(), )
-    return (int(ma.group(1), 16), False)
+    bits = image.bits()
+    if "buffer" in repr(bits):
+        ma = _re_buffer_address_match(repr(image.bits()))
+        assert ma, 'could not parse address from %r' % (image.bits(), )
+        return (int(ma.group(1), 16), False)
+    return bits
 
 getdata = dict(
     PyQt4 = PyQt_data,

--- a/test/test_qimageview.py
+++ b/test/test_qimageview.py
@@ -9,11 +9,15 @@ def test_viewcreation():
     qimg = QtGui.QImage(320, 240, QtGui.QImage.Format_RGB32)
     v = _qimageview(qimg)
     assert_equal(v.shape, (240, 320))
-    assert v.base is qimg
-    del qimg
-    w, h = v.base.width(), v.base.height() # should not segfault
-    assert_equal((w, h), (320, 240))
-
+    assert v.base
+    if v.base is qimg:
+        del qimg
+        w, h = v.base.width(), v.base.height() # should not segfault
+        assert_equal((w, h), (320, 240))
+    else:
+        # PySide returns a memoryview in Python 3 and a buffer in Python 2
+        del qimg
+        assert(v.base[10] is not None)
 
 @raises(TypeError)
 def test_qimageview_noargs():


### PR DESCRIPTION
As noted in issue #3, PySide returns a `memoryview` object in Python 3. These view objects support the buffer interface, so they can be passed directly to the `data` attribute in `__array_interface__`.