### PR TITLE
Package the license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include LICENSE.txt
 include doc/index.rst doc/Makefile doc/make.bat doc/conf.py
 recursive-include doc/html *.html *.css *.js *.png


### PR DESCRIPTION
Add the license file to `MANIFEST.in` so that it is included in `sdist`s and related packages.