### PR TITLE
check bool arrays before normalisation

### DIFF
--- a/qimage2ndarray/__init__.py
+++ b/qimage2ndarray/__init__.py
@@ -176,6 +176,9 @@ def recarray_view(qimage):
 
 def _normalize255(array, normalize, clip = (0, 255)):
     if normalize:
+        if array.dtype == 'bool':
+            array = array.astype(float)
+
         if normalize is True:
             normalize = array.min(), array.max()
             if clip == (0, 255):


### PR DESCRIPTION
Added a check at the start of _normalize255 to check for Boolean arrays and convert them to float. This allows them to be normalised between 0-255.